### PR TITLE
Force lon/lat to max 4 decimals

### DIFF
--- a/MMM-Weather-SMHI.js
+++ b/MMM-Weather-SMHI.js
@@ -523,10 +523,12 @@ Module.register("MMM-Weather-SMHI", {
 			[
 				this
 					.config
-					.lon,
+					.lon
+					.toFixed(4),
 				this
 					.config
 					.lat
+					.toFixed(4)
 			]
 		);
 		var self = this;


### PR DESCRIPTION
SMHI API doesn’t accept more decimals on longitude or latitude.